### PR TITLE
Add YAML persistence and tests (using Jackson)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,9 @@ dependencies {
     //For Streaming to XML and JSON
     implementation("com.thoughtworks.xstream:xstream:1.4.18")
     implementation("org.codehaus.jettison:jettison:1.4.1")
-
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.2")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.14.2")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.2")
 }
 
 tasks.test {

--- a/notes.yaml
+++ b/notes.yaml
@@ -1,9 +1,1 @@
----
-- noteTitle: "YAMLTest"
-  notePriority: 5
-  noteCategory: "Tests"
-  isNoteArchived: false
-- noteTitle: "YAMLTest2"
-  notePriority: 4
-  noteCategory: "Tests"
-  isNoteArchived: false
+--- []

--- a/notes.yaml
+++ b/notes.yaml
@@ -1,0 +1,9 @@
+---
+- noteTitle: "YAMLTest"
+  notePriority: 5
+  noteCategory: "Tests"
+  isNoteArchived: false
+- noteTitle: "YAMLTest2"
+  notePriority: 4
+  noteCategory: "Tests"
+  isNoteArchived: false

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -3,6 +3,7 @@ import models.Note
 import mu.KotlinLogging
 import persistence.JSONSerializer
 import persistence.XMLSerializer
+import persistence.YAMLSerializer
 import utils.ScannerInput
 import utils.ScannerInput.readNextInt
 import utils.ScannerInput.readNextLine
@@ -15,8 +16,9 @@ private val logger = KotlinLogging.logger {}
 
 val scanner = ScannerInput
 
-private val noteAPI = NoteAPI(XMLSerializer(File("notes.xml")))
+//private val noteAPI = NoteAPI(XMLSerializer(File("notes.xml")))
 //private val noteAPI = NoteAPI(JSONSerializer(File("notes.json")))
+private val noteAPI = NoteAPI(YAMLSerializer(File("notes.yaml")))
 
 
 

--- a/src/main/kotlin/persistence/YAMLSerializer.kt
+++ b/src/main/kotlin/persistence/YAMLSerializer.kt
@@ -1,0 +1,50 @@
+package persistence
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import com.fasterxml.jackson.module.kotlin.KotlinFeature
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.SingletonSupport
+import models.Note
+import java.io.File
+
+// https://www.mkammerer.de/blog/kotlin-and-yaml-part-2/
+class YAMLSerializer(private val file: File) : Serializer {
+
+    @Throws(Exception::class)
+    override fun read(): Any {
+        val mapper: ObjectMapper = YAMLMapper()
+        mapper.registerModule(
+            KotlinModule.Builder()
+                .withReflectionCacheSize(512)
+                .configure(KotlinFeature.NullToEmptyCollection, false)
+                .configure(KotlinFeature.NullToEmptyMap, false)
+                .configure(KotlinFeature.NullIsSameAsDefault, false)
+                .configure(KotlinFeature.SingletonSupport, false)
+                .configure(KotlinFeature.StrictNullChecks, false)
+                .build()
+        )
+
+        return mapper.readValue(file, object: TypeReference<ArrayList<Note?>?>(){})!!
+    }
+
+
+    @Throws(Exception::class)
+    override fun write(obj: Any?) {
+        val mapper: ObjectMapper = YAMLMapper()
+        mapper.registerModule(
+            KotlinModule.Builder()
+                .withReflectionCacheSize(512)
+                .configure(KotlinFeature.NullToEmptyCollection, false)
+                .configure(KotlinFeature.NullToEmptyMap, false)
+                .configure(KotlinFeature.NullIsSameAsDefault, false)
+                .configure(KotlinFeature.SingletonSupport, false)
+                .configure(KotlinFeature.StrictNullChecks, false)
+                .build()
+        )
+
+        mapper.writeValue(file, obj)
+    }
+}

--- a/src/test/kotlin/controllers/NoteAPITest.kt
+++ b/src/test/kotlin/controllers/NoteAPITest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import persistence.JSONSerializer
 import persistence.XMLSerializer
+import persistence.YAMLSerializer
 import java.io.File
 import kotlin.test.assertEquals
 
@@ -276,6 +277,44 @@ class NoteAPITest {
             loadedNotes.load()
 
             //Comparing the source of the notes (storingNotes) with the json loaded notes (loadedNotes)
+            assertEquals(3, storingNotes.numberOfNotes())
+            assertEquals(3, loadedNotes.numberOfNotes())
+            assertEquals(storingNotes.numberOfNotes(), loadedNotes.numberOfNotes())
+            assertEquals(storingNotes.findNote(0), loadedNotes.findNote(0))
+            assertEquals(storingNotes.findNote(1), loadedNotes.findNote(1))
+            assertEquals(storingNotes.findNote(2), loadedNotes.findNote(2))
+        }
+
+        @Test
+        fun `saving and loading an empty collection in YAML doesn't crash app`() {
+            // Saving an empty notes.yaml file.
+            val storingNotes = NoteAPI(YAMLSerializer(File("notes.yaml")))
+            storingNotes.store()
+
+            //Loading the empty notes.yaml file into a new object
+            val loadedNotes = NoteAPI(YAMLSerializer(File("notes.yaml")))
+            loadedNotes.load()
+
+            //Comparing the source of the notes (storingNotes) with the yaml loaded notes (loadedNotes)
+            assertEquals(0, storingNotes.numberOfNotes())
+            assertEquals(0, loadedNotes.numberOfNotes())
+            assertEquals(storingNotes.numberOfNotes(), loadedNotes.numberOfNotes())
+        }
+
+        @Test
+        fun `saving and loading an loaded collection in YAML doesn't loose data`() {
+            // Storing 3 notes to the notes.yaml file.
+            val storingNotes = NoteAPI(YAMLSerializer(File("notes.yaml")))
+            storingNotes.add(testApp!!)
+            storingNotes.add(swim!!)
+            storingNotes.add(summerHoliday!!)
+            storingNotes.store()
+
+            //Loading notes.yaml into a different collection
+            val loadedNotes = NoteAPI(YAMLSerializer(File("notes.yaml")))
+            loadedNotes.load()
+
+            //Comparing the source of the notes (storingNotes) with the yaml loaded notes (loadedNotes)
             assertEquals(3, storingNotes.numberOfNotes())
             assertEquals(3, loadedNotes.numberOfNotes())
             assertEquals(storingNotes.numberOfNotes(), loadedNotes.numberOfNotes())


### PR DESCRIPTION
Ended up using [Jackson](https://github.com/FasterXML/jackson) instead of [SnakeYAML](https://bitbucket.org/snakeyaml/snakeyaml/src/master/), because SnakeYAML doesn't have Kotlin support (or at least I couldn't find it)
```gradle
implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.2")
implementation("com.fasterxml.jackson.core:jackson-databind:2.14.2")
implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.2")
```

This article was very helpful for the Kotlin implementation: https://www.mkammerer.de/blog/kotlin-and-yaml-part-2/

Resolves #15 