### PR TITLE
Serializer validation, separate files for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ outTmp/
 /kotlin-native/dist
 kotlin-ide/
 /htmlReport/
+notes.test.json
+notes.test.yaml
+notes.test.xml

--- a/notes.json
+++ b/notes.json
@@ -1,1 +1,1 @@
-{"object-stream":{"list":[""]}}
+{"object-stream":{"list":[{"models.Note":[{"noteTitle":"JSONTestNote","notePriority":5,"noteCategory":"Tests","isNoteArchived":false},{"noteTitle":"JSONTestNote2","notePriority":4,"noteCategory":"Tests","isNoteArchived":false}]}]}}

--- a/notes.yaml
+++ b/notes.yaml
@@ -1,1 +1,9 @@
---- []
+---
+- noteTitle: "YAMLTest"
+  notePriority: 5
+  noteCategory: "Tests"
+  isNoteArchived: false
+- noteTitle: "YAMLTest2"
+  notePriority: 4
+  noteCategory: "Tests"
+  isNoteArchived: false

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -176,7 +176,11 @@ fun save() {
 
 fun load() {
     try {
-        noteAPI.load()
+        if (noteAPI.load()) {
+            println("Notes loaded successfully")
+        } else {
+            println("No notes to load")
+        }
     } catch (e: Exception) {
         System.err.println("Error reading from file: $e")
     }

--- a/src/main/kotlin/controllers/NoteAPI.kt
+++ b/src/main/kotlin/controllers/NoteAPI.kt
@@ -76,14 +76,14 @@ class NoteAPI(serializerType: Serializer) {
 
 
     @Throws(Exception::class)
-    fun load() {
-        notes = serializer.read() as ArrayList<Note>
-    }
+    fun load(): Boolean =
+        serializer.read()?.also {
+            notes = it
+        } != null
+
 
     @Throws(Exception::class)
-    fun store() {
-        serializer.write(notes)
-    }
+    fun store() = serializer.write(notes)
 
 
 }

--- a/src/main/kotlin/persistence/JSONSerializer.kt
+++ b/src/main/kotlin/persistence/JSONSerializer.kt
@@ -3,26 +3,29 @@ package persistence
 import com.thoughtworks.xstream.XStream
 import com.thoughtworks.xstream.io.json.JettisonMappedXmlDriver
 import models.Note
+import utils.SerializerUtils.isArrayList
 import java.io.File
 import java.io.FileReader
 import java.io.FileWriter
 
 class JSONSerializer(private val file: File) : Serializer {
     @Throws(Exception::class)
-    override fun read(): Any {
+    override fun read(): ArrayList<Note>? {
         val xStream = XStream(JettisonMappedXmlDriver())
         xStream.allowTypes(arrayOf(Note::class.java))
-        val inputStream = xStream.createObjectInputStream(FileReader(file))
-        val obj = inputStream.readObject() as Any
-        inputStream.close()
-        return obj
+        val obj = xStream.createObjectInputStream(FileReader(file)).use {
+            it.readObject() as Any
+        }
+
+        return isArrayList(obj)
     }
 
     @Throws(Exception::class)
-    override fun write(obj: Any?) {
+    override fun write(obj: ArrayList<Note>) {
         val xStream = XStream(JettisonMappedXmlDriver())
-        val outputStream = xStream.createObjectOutputStream(FileWriter(file))
-        outputStream.writeObject(obj)
-        outputStream.close()
+
+        xStream.createObjectOutputStream(FileWriter(file)).use {
+            it.writeObject(obj)
+        }
     }
 }

--- a/src/main/kotlin/persistence/Serializer.kt
+++ b/src/main/kotlin/persistence/Serializer.kt
@@ -1,9 +1,11 @@
 package persistence
 
+import models.Note
+
 interface Serializer {
     @Throws(Exception::class)
-    fun write(obj: Any?)
+    fun write(obj: ArrayList<Note>)
 
     @Throws(Exception::class)
-    fun read(): Any?
+    fun read(): ArrayList<Note>?
 }

--- a/src/main/kotlin/persistence/XMLSerializer.kt
+++ b/src/main/kotlin/persistence/XMLSerializer.kt
@@ -5,6 +5,8 @@ import kotlin.Throws
 import com.thoughtworks.xstream.XStream
 import com.thoughtworks.xstream.io.xml.DomDriver
 import models.Note
+import utils.SerializerUtils
+import utils.SerializerUtils.isArrayList
 import java.io.FileReader
 import java.io.FileWriter
 import java.lang.Exception
@@ -12,21 +14,23 @@ import java.lang.Exception
 class XMLSerializer(private val file: File) : Serializer {
 
     @Throws(Exception::class)
-    override fun read(): Any {
+    override fun read(): ArrayList<Note>? {
         val xStream = XStream(DomDriver())
         xStream.allowTypes(arrayOf(Note::class.java))
-        val inputStream = xStream.createObjectInputStream(FileReader(file))
-        val obj = inputStream.readObject() as Any
-        inputStream.close()
-        return obj
+        val obj = xStream.createObjectInputStream(FileReader(file)).use {
+            it.readObject() as Any
+        }
+
+        return isArrayList(obj)
     }
 
 
     @Throws(Exception::class)
-    override fun write(obj: Any?) {
+    override fun write(obj: ArrayList<Note>) {
         val xStream = XStream(DomDriver())
-        val outputStream = xStream.createObjectOutputStream(FileWriter(file))
-        outputStream.writeObject(obj)
-        outputStream.close()
+
+        xStream.createObjectOutputStream(FileWriter(file)).use {
+            it.writeObject(obj)
+        }
     }
 }

--- a/src/main/kotlin/persistence/YAMLSerializer.kt
+++ b/src/main/kotlin/persistence/YAMLSerializer.kt
@@ -8,13 +8,14 @@ import com.fasterxml.jackson.module.kotlin.KotlinFeature
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.SingletonSupport
 import models.Note
+import utils.SerializerUtils.isArrayList
 import java.io.File
 
 // https://www.mkammerer.de/blog/kotlin-and-yaml-part-2/
 class YAMLSerializer(private val file: File) : Serializer {
 
     @Throws(Exception::class)
-    override fun read(): Any {
+    override fun read(): ArrayList<Note>? {
         val mapper: ObjectMapper = YAMLMapper()
         mapper.registerModule(
             KotlinModule.Builder()
@@ -27,12 +28,14 @@ class YAMLSerializer(private val file: File) : Serializer {
                 .build()
         )
 
-        return mapper.readValue(file, object: TypeReference<ArrayList<Note?>?>(){})!!
+        val obj = mapper.readValue(file, object: TypeReference<ArrayList<Note?>?>(){})!!
+
+        return isArrayList(obj)
     }
 
 
     @Throws(Exception::class)
-    override fun write(obj: Any?) {
+    override fun write(obj: ArrayList<Note>) {
         val mapper: ObjectMapper = YAMLMapper()
         mapper.registerModule(
             KotlinModule.Builder()

--- a/src/main/kotlin/utils/SerializerUtils.kt
+++ b/src/main/kotlin/utils/SerializerUtils.kt
@@ -1,0 +1,13 @@
+package utils
+
+import models.Note
+
+object SerializerUtils {
+    @JvmStatic
+    fun isArrayList(obj: Any): ArrayList<Note>? = if (obj is ArrayList<*> && obj.all { it is Note }) {
+        @Suppress("UNCHECKED_CAST")
+        obj as ArrayList<Note>
+    } else {
+        null
+    }
+}

--- a/src/test/kotlin/controllers/NoteAPITest.kt
+++ b/src/test/kotlin/controllers/NoteAPITest.kt
@@ -19,8 +19,8 @@ class NoteAPITest {
     private var codeApp: Note? = null
     private var testApp: Note? = null
     private var swim: Note? = null
-    private var populatedNotes: NoteAPI? = NoteAPI(XMLSerializer(File("notes.xml")))
-    private var emptyNotes: NoteAPI? = NoteAPI(XMLSerializer(File("notes.xml")))
+    private var populatedNotes: NoteAPI? = NoteAPI(XMLSerializer(File("notes.test.xml")))
+    private var emptyNotes: NoteAPI? = NoteAPI(XMLSerializer(File("notes.test.xml")))
 
     @BeforeEach
     fun setup(){
@@ -47,6 +47,10 @@ class NoteAPITest {
         swim = null
         populatedNotes = null
         emptyNotes = null
+
+        File("notes.test.xml").delete()
+        File("notes.test.json").delete()
+        File("notes.test.yaml").delete()
     }
 
     @Test
@@ -230,11 +234,11 @@ class NoteAPITest {
         @Test
         fun `saving and loading an empty collection in XML doesn't crash app`() {
             // Saving an empty notes.XML file.
-            val storingNotes = NoteAPI(XMLSerializer(File("notes.xml")))
+            val storingNotes = NoteAPI(XMLSerializer(File("notes.test.xml")))
             storingNotes.store()
 
-            //Loading the empty notes.xml file into a new object
-            val loadedNotes = NoteAPI(XMLSerializer(File("notes.xml")))
+            //Loading the empty notes.test.xml file into a new object
+            val loadedNotes = NoteAPI(XMLSerializer(File("notes.test.xml")))
             loadedNotes.load()
 
             //Comparing the source of the notes (storingNotes) with the XML loaded notes (loadedNotes)
@@ -246,14 +250,14 @@ class NoteAPITest {
         @Test
         fun `saving and loading an loaded collection in XML doesn't loose data`() {
             // Storing 3 notes to the notes.XML file.
-            val storingNotes = NoteAPI(XMLSerializer(File("notes.xml")))
+            val storingNotes = NoteAPI(XMLSerializer(File("notes.test.xml")))
             storingNotes.add(testApp!!)
             storingNotes.add(swim!!)
             storingNotes.add(summerHoliday!!)
             storingNotes.store()
 
-            //Loading notes.xml into a different collection
-            val loadedNotes = NoteAPI(XMLSerializer(File("notes.xml")))
+            //Loading notes.test.xml into a different collection
+            val loadedNotes = NoteAPI(XMLSerializer(File("notes.test.xml")))
             loadedNotes.load()
 
             //Comparing the source of the notes (storingNotes) with the XML loaded notes (loadedNotes)
@@ -267,12 +271,12 @@ class NoteAPITest {
 
         @Test
         fun `saving and loading an empty collection in JSON doesn't crash app`() {
-            // Saving an empty notes.json file.
-            val storingNotes = NoteAPI(JSONSerializer(File("notes.json")))
+            // Saving an empty notes.test.json file.
+            val storingNotes = NoteAPI(JSONSerializer(File("notes.test.json")))
             storingNotes.store()
 
-            //Loading the empty notes.json file into a new object
-            val loadedNotes = NoteAPI(JSONSerializer(File("notes.json")))
+            //Loading the empty notes.test.json file into a new object
+            val loadedNotes = NoteAPI(JSONSerializer(File("notes.test.json")))
             loadedNotes.load()
 
             //Comparing the source of the notes (storingNotes) with the json loaded notes (loadedNotes)
@@ -283,15 +287,15 @@ class NoteAPITest {
 
         @Test
         fun `saving and loading an loaded collection in JSON doesn't loose data`() {
-            // Storing 3 notes to the notes.json file.
-            val storingNotes = NoteAPI(JSONSerializer(File("notes.json")))
+            // Storing 3 notes to the notes.test.json file.
+            val storingNotes = NoteAPI(JSONSerializer(File("notes.test.json")))
             storingNotes.add(testApp!!)
             storingNotes.add(swim!!)
             storingNotes.add(summerHoliday!!)
             storingNotes.store()
 
-            //Loading notes.json into a different collection
-            val loadedNotes = NoteAPI(JSONSerializer(File("notes.json")))
+            //Loading notes.test.json into a different collection
+            val loadedNotes = NoteAPI(JSONSerializer(File("notes.test.json")))
             loadedNotes.load()
 
             //Comparing the source of the notes (storingNotes) with the json loaded notes (loadedNotes)
@@ -305,12 +309,12 @@ class NoteAPITest {
 
         @Test
         fun `saving and loading an empty collection in YAML doesn't crash app`() {
-            // Saving an empty notes.yaml file.
-            val storingNotes = NoteAPI(YAMLSerializer(File("notes.yaml")))
+            // Saving an empty notes.test.yaml file.
+            val storingNotes = NoteAPI(YAMLSerializer(File("notes.test.yaml")))
             storingNotes.store()
 
-            //Loading the empty notes.yaml file into a new object
-            val loadedNotes = NoteAPI(YAMLSerializer(File("notes.yaml")))
+            //Loading the empty notes.test.yaml file into a new object
+            val loadedNotes = NoteAPI(YAMLSerializer(File("notes.test.yaml")))
             loadedNotes.load()
 
             //Comparing the source of the notes (storingNotes) with the yaml loaded notes (loadedNotes)
@@ -321,15 +325,15 @@ class NoteAPITest {
 
         @Test
         fun `saving and loading an loaded collection in YAML doesn't loose data`() {
-            // Storing 3 notes to the notes.yaml file.
-            val storingNotes = NoteAPI(YAMLSerializer(File("notes.yaml")))
+            // Storing 3 notes to the notes.test.yaml file.
+            val storingNotes = NoteAPI(YAMLSerializer(File("notes.test.yaml")))
             storingNotes.add(testApp!!)
             storingNotes.add(swim!!)
             storingNotes.add(summerHoliday!!)
             storingNotes.store()
 
-            //Loading notes.yaml into a different collection
-            val loadedNotes = NoteAPI(YAMLSerializer(File("notes.yaml")))
+            //Loading notes.test.yaml into a different collection
+            val loadedNotes = NoteAPI(YAMLSerializer(File("notes.test.yaml")))
             loadedNotes.load()
 
             //Comparing the source of the notes (storingNotes) with the yaml loaded notes (loadedNotes)


### PR DESCRIPTION
Also adds back notes to the `.yaml` and `.json` files respectively, they were accidentally removed because of the old testing methods.

> **Warning**: A new _small_ bug has been introduced that doesn't really affect anything: The new `notes.test.json` file is not removed when JUnit tests are finished. The test files should _all_ be removed when tests are finished, however the JSON file isn't for some reason. This might be an issue related to [Java File Streams](https://stackoverflow.com/questions/4485716/java-file-delete-is-not-deleting-specified-file)? However, I am using Kotlin's [`use`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.io/use.html) which should close down all resources at the end.